### PR TITLE
Selects last element in descending list instead of first

### DIFF
--- a/src/WeatherObservations/IntentHandlers/WeatherObservations/WeatherObservationsIntentHandler.cs
+++ b/src/WeatherObservations/IntentHandlers/WeatherObservations/WeatherObservationsIntentHandler.cs
@@ -68,7 +68,7 @@ public class WeatherObservationsIntentHandler : IWeatherObservationsIntentHandle
             date = skyConditions
                 .Select(x => x.Value)
                 .OrderByDescending(x => x.ObservationTimeUtc)
-                .First()
+                .Last()
                 .ObservationTimeLocal;
         }
 


### PR DESCRIPTION
By selecting the first element in the descending list, SkyBro would report the latest date rather than the earliest when a date was not provided.

- closes: #11 